### PR TITLE
Add team visualization modal

### DIFF
--- a/src/components/commons/collections/team-card/team-card.jsx
+++ b/src/components/commons/collections/team-card/team-card.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 
 import { Button, Card, Avatar, Tooltip } from '@material-ui/core'
@@ -6,28 +6,38 @@ import RoleIconList from '../role-icon-list/role-icon-list'
 
 import styles from './team-card.module.scss'
 import { useArrayHandler } from 'hooks/use-array-handler'
+import TeamDetails from 'components/pages/team/team-details/team-details'
 
 const TeamCard = ({ data }) => {
+	const [openModal, setOpenModal] = useState(false)
+
+	function onCloseModal() {
+		setOpenModal(false)
+	}
+
 	return (
-		<Card className={styles.container}>
-			<h2>{data.name}</h2>
-			<p>{data.description}</p>
-			<h3>Membros:</h3>
-			<div className={styles.membersRow}>
-				{[...data.members, data.owner].map(member =>
-					<Tooltip key={member.name} title={member.name}>
-						<Avatar src={member.name} alt={member.name} />
-					</Tooltip>
-				)}
-			</div>
-			<h3>Procurando:</h3>
-			<div className={styles.lastLine}>
-				<RoleIconList roles={useArrayHandler(data.needed_skills)} />
-				<div className={styles.btnContainer}>
-					<Button variant="contained" color="secondary">Detalhes</Button>
+		<>
+			<Card className={styles.container}>
+				<h2>{data.name}</h2>
+				<p>{data.description}</p>
+				<h3>Membros:</h3>
+				<div className={styles.membersRow}>
+					{[...data.members, data.owner].map(member =>
+						<Tooltip key={member.name} title={member.name}>
+							<Avatar src={member.name} alt={member.name} />
+						</Tooltip>
+					)}
 				</div>
-			</div>
-		</Card>
+				<h3>Procurando:</h3>
+				<div className={styles.lastLine}>
+					<RoleIconList roles={useArrayHandler(data.needed_skills)} />
+					<div className={styles.btnContainer}>
+						<Button variant="contained" color="secondary" onClick={() => setOpenModal(!openModal)}>Detalhes</Button>
+					</div>
+				</div>
+			</Card>
+			<TeamDetails data={data} open={openModal} onClose={onCloseModal} />
+		</>
 	)
 }
 

--- a/src/components/pages/team/team-details/team-details.jsx
+++ b/src/components/pages/team/team-details/team-details.jsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import RoleIconList from 'components/commons/collections/role-icon-list/role-icon-list'
+import { useArrayHandler } from 'hooks/use-array-handler'
+
+import PersonAddIcon from '@material-ui/icons/PersonAdd'
+import { Button, Dialog, Avatar, List, ListItem, ListItemAvatar, ListItemText } from '@material-ui/core'
+import styles from './team-details.module.scss'
+
+const TeamDetails = ({ data, open, onClose }) => {
+	return (
+		<Dialog open={open} onClose={onClose}>
+			<div className={styles.container}>
+				<h2>{data.name}</h2>
+				<p>{data.description}</p>
+				<h2>Membros</h2>
+
+				<List>
+					{[...data.members, data.owner].map(member =>
+						<ListItem key={member.name}>
+							<ListItemAvatar>
+								<Avatar src={member.name} alt={member.name} />
+							</ListItemAvatar>
+							<ListItemText primary={member.name} />
+						</ListItem>
+					)}
+				</List>
+				<h2>Procurando</h2>
+				<List>
+					<ListItem>
+						<RoleIconList roles={useArrayHandler(data.needed_skills)} />
+					</ListItem>
+				</List>
+				<div className={styles.btnContainer}>
+					<Button variant="contained" color="secondary" startIcon={<PersonAddIcon />}>
+						Participar do time
+					</Button>
+				</div>
+			</div>
+		</Dialog>
+	)
+}
+
+TeamDetails.propTypes = {
+	data: PropTypes.object.isRequired,
+	open: PropTypes.bool.isRequired,
+	onClose: PropTypes.func.isRequired
+}
+
+export default TeamDetails

--- a/src/components/pages/team/team-details/team-details.module.scss
+++ b/src/components/pages/team/team-details/team-details.module.scss
@@ -1,0 +1,17 @@
+@import "styles/colors.scss";
+@import "styles//breakpoints.scss";
+
+.container {
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+  width: 420px;
+  padding: 16px;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 8px;
+}


### PR DESCRIPTION
# Motivation
We need to add an option to show a detailed view of a team when clicking on 'Detalhes'.

![image](https://github.com/jamtasticgd/jamtastic/assets/13919606/e4e72d32-5bd9-41f1-88ba-59ba333df7a8)

![image](https://github.com/jamtasticgd/jamtastic/assets/13919606/8d2da67d-4b5b-4651-9424-b5ee82375a4d)
